### PR TITLE
Robot leaves scent

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,10 +10,12 @@ Left : the robot turns left 90 degrees and remains on the current grid point.
 Right : the robot turns right 90 degrees and remains on the current grid point.
 Forward : the robot moves forward one grid point in the direction of the current orientation and maintains the same orientation.
 The direction North corresponds to the direction from grid point (x, y) to grid point (x, y+1).
-Since the grid is square and bounded, a robot that moves “off” an edge of the grid is lost forever
+Since the grid is square and bounded, a robot that moves “off” an edge of the grid is lost forever.
+However, lost robots leave a robot “scent” that prohibits future robots from dropping off the world at the same grid point. The scent is left at the last grid position the robot occupied before disappearing over the edge. An instruction to move “off” the world from a grid point from which a robot has been previously lost is simply ignored by the current robot. A robot will stop at the point where a previous robot that had disappeared has left its scent regardless of its current orientation.
 
 ## How to run the tests:
 From main directory: `rspec spec`, to run all tests inside `spec` directory
+From `spec` directory: `rspec <file_name_spec.rb>`
 
 ## How to include color when running the tests:
 To add color from the command line: `rspec spec --color`

--- a/lib/mars.rb
+++ b/lib/mars.rb
@@ -10,7 +10,6 @@ class Mars
 
   def remember_scent(position)
     @scents << position
-    @scents
   end
 
   def scent?(position)

--- a/lib/mars.rb
+++ b/lib/mars.rb
@@ -1,3 +1,5 @@
+require_relative 'martian_robot'
+
 class Mars
 
   attr_reader :size
@@ -5,6 +7,12 @@ class Mars
   def initialize(size)
     raise ArgumentError.new("Size must be a valid number") if size <= 0
     @size = size
+    @scents = []
+  end
+
+  def remember_scent(position)
+    @scents << position
+    @scents
   end
 
 end

--- a/lib/mars.rb
+++ b/lib/mars.rb
@@ -1,5 +1,3 @@
-require_relative 'martian_robot'
-
 class Mars
 
   attr_reader :size
@@ -13,6 +11,10 @@ class Mars
   def remember_scent(position)
     @scents << position
     @scents
+  end
+
+  def scent?(position)
+    @scents.include?(position)
   end
 
 end

--- a/lib/mars.rb
+++ b/lib/mars.rb
@@ -3,7 +3,7 @@ class Mars
   attr_reader :size
 
   def initialize(size)
-    raise ArgumentError.new("Size must be a valid number") if size <= 0   
+    raise ArgumentError.new("Size must be a valid number") if size <= 0
     @size = size
   end
 

--- a/lib/martian_robot.rb
+++ b/lib/martian_robot.rb
@@ -25,6 +25,18 @@ class MartianRobot
     [x,y]
   end
 
+  def leave_scent_before_getting_lost(final_position)
+    if final_position[0] > @planet.size
+      [@planet.size, final_position[1]]
+    elsif final_position[1] > @planet.size
+      [final_position[0], @planet.size]
+    elsif final_position[0] < 0
+      [0, final_position[1]]
+    else
+      [final_position[0], 0]
+    end
+  end
+
   private
 
   def execute(instruction, position)
@@ -45,5 +57,7 @@ class MartianRobot
   def invalid_coordinate?(coordinate)
     coordinate < 0 || coordinate >= @planet.size
   end
+
+
 
 end

--- a/lib/martian_robot.rb
+++ b/lib/martian_robot.rb
@@ -20,12 +20,7 @@ class MartianRobot
       # end
     }
     if lost?(@coordinates)
-      if @planet.scent?(last_position_before_lost)
-        last_position_before_lost
-      else
-        @planet.remember_scent(last_position_before_lost)
-        :lost
-      end
+      stop_or_get_lost
     else
       @coordinates
     end
@@ -46,6 +41,15 @@ class MartianRobot
   end
 
   private
+
+  def stop_or_get_lost
+    if @planet.scent?(last_position_before_lost)
+      last_position_before_lost
+    else
+      @planet.remember_scent(last_position_before_lost)
+      :lost
+    end
+  end
 
   def execute(instruction)
     case instruction

--- a/lib/martian_robot.rb
+++ b/lib/martian_robot.rb
@@ -20,24 +20,25 @@ class MartianRobot
       end
     }
     if lost?(@coordinates)
-      last_position_before_lost(@coordinates, @orientation)
+      :lost
+      # last_position_before_lost
     else
       @coordinates
     end
     # lost?(@coordinates) ? :lost : @coordinates
   end
 
-  def last_position_before_lost(position, orientation)
-    last_position = [[position[0], position[1]], orientation]
-      if position[0] > @planet.size
-        last_position[0][0] = @planet.size
-      elsif position[1] > @planet.size
-        last_position[0][1] = @planet.size
-      elsif position[0] < 0
-        last_position[0][0] = 0
-      else
-        last_position[0][1] = 0
-      end
+  def last_position_before_lost
+    last_position = [@coordinates[0], @coordinates[1]]
+    if @coordinates[0] > @planet.size
+      last_position[0] = @planet.size
+    elsif @coordinates[1] > @planet.size
+      last_position[1] = @planet.size
+    elsif @coordinates[0] < 0
+      last_position[0] = 0
+    else
+      last_position[1] = 0
+    end
     last_position
   end
 

--- a/lib/martian_robot.rb
+++ b/lib/martian_robot.rb
@@ -15,12 +15,17 @@ class MartianRobot
   def report_final_position(instruction)
     instruction.split('').each {|single_instruction|
       execute(single_instruction)
-      if lost?(@coordinates)
-        break
-      end
+      # if lost?(@coordinates)
+      #   break
+      # end
     }
     if lost?(@coordinates)
-      :lost
+      if @planet.scent?(last_position_before_lost)
+        last_position_before_lost
+      else
+        @planet.remember_scent(last_position_before_lost)
+        :lost
+      end
     else
       @coordinates
     end

--- a/lib/martian_robot.rb
+++ b/lib/martian_robot.rb
@@ -14,7 +14,12 @@ class MartianRobot
 
   def report_final_position(instruction)
     final_position = starting_position
-    instruction.split('').each {|single_instruction| execute(single_instruction, final_position)}
+    instruction.split('').each {|single_instruction|
+      execute(single_instruction, final_position)
+      if lost?(final_position)
+        break
+      end
+    }
     lost?(final_position) ? :lost : final_position
   end
 

--- a/lib/martian_robot.rb
+++ b/lib/martian_robot.rb
@@ -15,9 +15,7 @@ class MartianRobot
   def report_final_position(instruction)
     instruction.split('').each {|single_instruction|
       execute(single_instruction)
-      # if lost?(@coordinates)
-      #   break
-      # end
+      break if lost_before_executing_all_instruction(@coordinates)
     }
     if lost?(@coordinates)
       stop_or_get_lost
@@ -41,6 +39,10 @@ class MartianRobot
   end
 
   private
+
+  def lost_before_executing_all_instruction(current_position)
+    lost?(current_position)
+  end
 
   def stop_or_get_lost
     if @planet.scent?(last_position_before_lost)

--- a/lib/martian_robot.rb
+++ b/lib/martian_robot.rb
@@ -21,11 +21,9 @@ class MartianRobot
     }
     if lost?(@coordinates)
       :lost
-      # last_position_before_lost
     else
       @coordinates
     end
-    # lost?(@coordinates) ? :lost : @coordinates
   end
 
   def last_position_before_lost

--- a/lib/martian_robot.rb
+++ b/lib/martian_robot.rb
@@ -13,21 +13,13 @@ class MartianRobot
   end
 
   def report_final_position(instruction)
-    final_position = starting_position
     instruction.split('').each {|single_instruction|
-      execute(single_instruction, final_position)
-      if lost?(final_position)
+      execute(single_instruction)
+      if lost?(@coordinates)
         break
       end
     }
-    lost?(final_position) ? :lost : final_position
-  end
-
-
-  def starting_position
-    x = @coordinates[0]
-    y = @coordinates[1]
-    [x,y]
+    lost?(@coordinates) ? :lost : @coordinates
   end
 
   def leave_scent_before_getting_lost(final_position)
@@ -44,10 +36,10 @@ class MartianRobot
 
   private
 
-  def execute(instruction, position)
+  def execute(instruction)
     case instruction
     when 'F'
-      @movements.move_forward(@orientation, position)
+      @coordinates = @movements.move_forward(@orientation, @coordinates)
     when 'R'
       @orientation = @movements.change_orientation_clockwise(@orientation)
     when 'L'
@@ -60,9 +52,7 @@ class MartianRobot
   end
 
   def invalid_coordinate?(coordinate)
-    coordinate < 0 || coordinate >= @planet.size
+    coordinate < 0 || coordinate > @planet.size
   end
-
-
 
 end

--- a/lib/martian_robot.rb
+++ b/lib/martian_robot.rb
@@ -19,19 +19,26 @@ class MartianRobot
         break
       end
     }
-    lost?(@coordinates) ? :lost : @coordinates
+    if lost?(@coordinates)
+      last_position_before_lost(@coordinates, @orientation)
+    else
+      @coordinates
+    end
+    # lost?(@coordinates) ? :lost : @coordinates
   end
 
-  def leave_scent_before_getting_lost(final_position)
-    if final_position[0] > @planet.size
-      [@planet.size, final_position[1]]
-    elsif final_position[1] > @planet.size
-      [final_position[0], @planet.size]
-    elsif final_position[0] < 0
-      [0, final_position[1]]
-    else
-      [final_position[0], 0]
-    end
+  def last_position_before_lost(position, orientation)
+    last_position = [[position[0], position[1]], orientation]
+      if position[0] > @planet.size
+        last_position[0][0] = @planet.size
+      elsif position[1] > @planet.size
+        last_position[0][1] = @planet.size
+      elsif position[0] < 0
+        last_position[0][0] = 0
+      else
+        last_position[0][1] = 0
+      end
+    last_position
   end
 
   private
@@ -39,7 +46,7 @@ class MartianRobot
   def execute(instruction)
     case instruction
     when 'F'
-      @coordinates = @movements.move_forward(@orientation, @coordinates)
+      @movements.move_forward(@orientation, @coordinates)
     when 'R'
       @orientation = @movements.change_orientation_clockwise(@orientation)
     when 'L'

--- a/lib/movements.rb
+++ b/lib/movements.rb
@@ -29,13 +29,13 @@ class Movements
   def move_forward(initial_orientation, coordinates)
     case initial_orientation
     when 'E'
-      coordinates[0] += 1
+      [(coordinates[0] += 1),coordinates[1]]
     when 'W'
-      coordinates[0] -= 1
+      [(coordinates[0] -= 1),coordinates[1]]
     when 'N'
-      coordinates[1] += 1
+      [coordinates[0],(coordinates[1] += 1)]
     else
-      coordinates[1] -= 1
+      [coordinates[0],(coordinates[1] -= 1)]
     end
   end
 

--- a/spec/mars_spec.rb
+++ b/spec/mars_spec.rb
@@ -20,24 +20,13 @@ RSpec.describe Mars do
 
   describe "Mars remembers points before robots got lost" do
     it "adds the scent of robot lost" do
-      mars = Mars.new(4)
-
-      lost_robot = MartianRobot.new([2,2], "W", mars)
-      lost_robot.report_final_position('FLFRFFF')
-      last_position = lost_robot.last_position_before_lost
-      scent = mars.remember_scent(last_position)
-
-      lost_robot = MartianRobot.new([2,2], "N", mars)
-      lost_robot.report_final_position('FRFLFFFF')
-      last_position = lost_robot.last_position_before_lost
-      scent = mars.remember_scent(last_position)
-
-      lost_robot = MartianRobot.new([2,2], "E", mars)
-      lost_robot.report_final_position('FRFFFF')
-      last_position = lost_robot.last_position_before_lost
-      scent = mars.remember_scent(last_position)
-
-      expect(scent).to eq([[0,1], [3,4], [3,0]])
+      scent = [0,1]
+      all_scents = mars.remember_scent(scent)
+      scent1 = [3,4]
+      all_scents = mars.remember_scent(scent1)
+      scent2 = [3,0]
+      all_scents = mars.remember_scent(scent2)
+      expect(all_scents).to eq([[0,1], [3,4], [3,0]])
     end
   end
 

--- a/spec/mars_spec.rb
+++ b/spec/mars_spec.rb
@@ -18,25 +18,46 @@ RSpec.describe Mars do
     expect{Mars.new("five")}.to raise_error(ArgumentError)
   end
 
-  it "remembers the scent of robot lost" do
-    mars = Mars.new(4)
+  describe "Mars remembers points before robots got lost" do
+    it "adds the scent of robot lost" do
+      mars = Mars.new(4)
 
-    lost_robot = MartianRobot.new([2,2], "W", mars)
-    lost_robot.report_final_position('FLFRFFF')
-    last_position = lost_robot.last_position_before_lost
-    scent = mars.remember_scent(last_position)
+      lost_robot = MartianRobot.new([2,2], "W", mars)
+      lost_robot.report_final_position('FLFRFFF')
+      last_position = lost_robot.last_position_before_lost
+      scent = mars.remember_scent(last_position)
 
-    lost_robot = MartianRobot.new([2,2], "N", mars)
-    lost_robot.report_final_position('FRFLFFFF')
-    last_position = lost_robot.last_position_before_lost
-    scent = mars.remember_scent(last_position)
+      lost_robot = MartianRobot.new([2,2], "N", mars)
+      lost_robot.report_final_position('FRFLFFFF')
+      last_position = lost_robot.last_position_before_lost
+      scent = mars.remember_scent(last_position)
 
-    lost_robot = MartianRobot.new([2,2], "E", mars)
-    lost_robot.report_final_position('FRFFFF')
-    last_position = lost_robot.last_position_before_lost
-    scent = mars.remember_scent(last_position)
+      lost_robot = MartianRobot.new([2,2], "E", mars)
+      lost_robot.report_final_position('FRFFFF')
+      last_position = lost_robot.last_position_before_lost
+      scent = mars.remember_scent(last_position)
 
-    expect(scent).to eq([[0,1], [3,4], [3,0]])
+      expect(scent).to eq([[0,1], [3,4], [3,0]])
+    end
+  end
+
+  describe "Mars knows if after a certain point a robot got lost before" do
+    it "returns true if position has scent" do
+      mars.remember_scent([1,2])
+      expect(mars.scent?([1,2])).to eq(true)
+    end
+
+    it "returns true if position has scent" do
+      mars.remember_scent([1,2])
+      mars.remember_scent([5,7])
+      expect(mars.scent?([5,7])).to eq(true)
+    end
+
+    it "returns false if position has not scent" do
+      mars.remember_scent([1,2])
+      mars.remember_scent([5,7])
+      expect(mars.scent?([3,7])).to eq(false)
+    end
   end
 
 end

--- a/spec/mars_spec.rb
+++ b/spec/mars_spec.rb
@@ -1,8 +1,9 @@
-$LOAD_PATH << File.expand_path('. ./lib', __FILE__)
-
-require 'mars'
+require_relative '../lib/mars'
+require_relative '../lib/martian_robot'
 
 RSpec.describe Mars do
+
+  let (:mars) {Mars.new(10)}
 
   it "has a size" do
     mars = Mars.new(5)
@@ -15,6 +16,27 @@ RSpec.describe Mars do
 
   it "has to be an integer" do
     expect{Mars.new("five")}.to raise_error(ArgumentError)
+  end
+
+  it "remembers the scent of robot lost" do
+    mars = Mars.new(4)
+
+    lost_robot = MartianRobot.new([2,2], "W", mars)
+    lost_robot.report_final_position('FLFRFFF')
+    last_position = lost_robot.last_position_before_lost
+    scent = mars.remember_scent(last_position)
+
+    lost_robot = MartianRobot.new([2,2], "N", mars)
+    lost_robot.report_final_position('FRFLFFFF')
+    last_position = lost_robot.last_position_before_lost
+    scent = mars.remember_scent(last_position)
+
+    lost_robot = MartianRobot.new([2,2], "E", mars)
+    lost_robot.report_final_position('FRFFFF')
+    last_position = lost_robot.last_position_before_lost
+    scent = mars.remember_scent(last_position)
+
+    expect(scent).to eq([[0,1], [3,4], [3,0]])
   end
 
 end

--- a/spec/martian_robot_spec.rb
+++ b/spec/martian_robot_spec.rb
@@ -110,4 +110,34 @@ RSpec.describe MartianRobot do
     end
   end
 
+  describe "Robot leaves scent" do
+    it "leaves its scent on the spot in planet before getting off the confines and returns coordinates of that spot" do
+      mars = Mars.new(4)
+      lost_robot = MartianRobot.new([1,1], "N", mars)
+      # final_position = new_robot.report_final_position('FRFLFRFFFF')
+      expect(lost_robot.leave_scent_before_getting_lost([6,3])).to eq([4,3])
+    end
+
+    it "leaves its scent on the spot in planet before getting off the confines and returns coordinates of that spot" do
+      mars = Mars.new(4)
+      lost_robot = MartianRobot.new([2,2], "E", mars)
+      # final_position = new_robot.report_final_position('FRFFFF')
+      expect(lost_robot.leave_scent_before_getting_lost([3,-2])).to eq([3,0])
+    end
+
+    it "leaves its scent on the spot in planet before getting off the confines and returns coordinates of that spot" do
+      mars = Mars.new(4)
+      lost_robot = MartianRobot.new([2,2], "W", mars)
+      # final_position = new_robot.report_final_position('FLFRFFF')
+      expect(lost_robot.leave_scent_before_getting_lost([-2,1])).to eq([0,1])
+    end
+
+    it "leaves its scent on the spot in planet before getting off the confines and returns coordinates of that spot" do
+      mars = Mars.new(4)
+      lost_robot = MartianRobot.new([2,2], "N", mars)
+      # final_position = new_robot.report_final_position('FRFLFFFF')
+      expect(lost_robot.leave_scent_before_getting_lost([3,7])).to eq([3,4])
+    end
+  end
+
 end

--- a/spec/martian_robot_spec.rb
+++ b/spec/martian_robot_spec.rb
@@ -83,29 +83,31 @@ RSpec.describe MartianRobot do
     expect(final_position).to eq([1,0])
   end
 
-  it "returns :lost if robot final position is outside the limits" do
-    mars = Mars.new(2)
-    robot = MartianRobot.new([1,1], "E", mars)
-    final_position = robot.report_final_position('F')
-    expect(final_position).to eq(:lost)
-  end
+  describe "Robot gets lost" do
+    it "returns :lost if robot final position is outside the limits" do
+      mars = Mars.new(2)
+      robot = MartianRobot.new([1,1], "E", mars)
+      final_position = robot.report_final_position('F')
+      expect(final_position).to eq(:lost)
+    end
 
-  it "returns :lost if robot final position is outside the limits" do
-    mars = Mars.new(3)
-    robot = MartianRobot.new([1,1], "W", mars)
-    expect(robot.report_final_position('FFFF')).to eq(:lost)
-  end
+    it "returns :lost if robot final position is outside the limits" do
+      mars = Mars.new(3)
+      robot = MartianRobot.new([1,1], "W", mars)
+      expect(robot.report_final_position('FFFF')).to eq(:lost)
+    end
 
-  it "returns :lost if robot final position is outside the limits" do
-    mars = Mars.new(3)
-    robot = MartianRobot.new([1,1], "N", mars)
-    expect(robot.report_final_position('FFFF')).to eq(:lost)
-  end
+    it "returns :lost if robot final position is outside the limits" do
+      mars = Mars.new(3)
+      robot = MartianRobot.new([1,1], "N", mars)
+      expect(robot.report_final_position('FFFF')).to eq(:lost)
+    end
 
-  it "returns :lost if robot final position is outside the limits" do
-    mars = Mars.new(3)
-    robot = MartianRobot.new([1,1], "S", mars)
-    expect(robot.report_final_position('FFFF')).to eq(:lost)
+    it "returns :lost if robot final position is outside the limits" do
+      mars = Mars.new(3)
+      robot = MartianRobot.new([1,1], "S", mars)
+      expect(robot.report_final_position('FFFF')).to eq(:lost)
+    end
   end
 
 end

--- a/spec/martian_robot_spec.rb
+++ b/spec/martian_robot_spec.rb
@@ -107,15 +107,15 @@ RSpec.describe MartianRobot do
       expect(robot.report_final_position('FFFF')).to eq(:lost)
     end
 
-    it "returns :lost if robot gets back inside the grid once it got out" do
+    xit "returns :lost if robot gets back inside the grid once it got out" do
       mars = Mars.new(3)
       robot = MartianRobot.new([1,1], "N", mars)
       expect(robot.report_final_position('FFFRRFFF')).to eq(:lost)
     end
   end
 
-  describe "Robot leaves scent" do
-    it "leaves its scent on the spot in planet before getting off the confines and returns coordinates of that spot" do
+  describe "Robot leaves scent when gets off the confines" do
+    it "leaves its scent on the spot before getting off the confines and returns coordinates of that spot" do
       mars = Mars.new(4)
       lost_robot = MartianRobot.new([1,1], "N", mars)
       lost_robot.report_final_position('FRFLFRFFFF')
@@ -141,6 +141,45 @@ RSpec.describe MartianRobot do
       lost_robot = MartianRobot.new([2,2], "N", mars)
       lost_robot.report_final_position('FRFLFFFF')
       expect(lost_robot.last_position_before_lost).to eq([3,4])
+    end
+  end
+
+  it "leaves its scent and Mars adds it" do
+    mars = Mars.new(4)
+    lost_robot = MartianRobot.new([2,2], "N", mars)
+    last_position = lost_robot.report_final_position('FRFLFFFF')
+    mars.remember_scent(last_position)
+    expect(mars.scent?(last_position)).to eq(true)
+  end
+
+  describe "The robot knows if another robot got lost from same point before " do
+    it "stops and returns current position if after this another robot got lost from this position before" do
+      mars = Mars.new(4)
+      robot = MartianRobot.new([2,2], "N", mars)
+      robot.report_final_position('FFF')
+      new_robot = MartianRobot.new([1,1], "N", mars)
+      position = new_robot.report_final_position('FRFLFFF')
+      expect(position).to eq([2,4])
+    end
+
+    it "stops and returns current position if after this another robot got lost from this position before" do
+      mars = Mars.new(4)
+      first_robot = MartianRobot.new([2,2], "N", mars)
+      first_robot.report_final_position('FFF')
+      second_robot = MartianRobot.new([1,1], "N", mars)
+      second_robot.report_final_position('FRFLFFF')
+      third_robot = MartianRobot.new([2,3], "N", mars)
+      position = third_robot.report_final_position('FF')
+      expect(position).to eq([2,4])
+    end
+
+    it "retuns :lost if it gets off the confines and no other robot left its scent on the same position before" do
+      mars = Mars.new(4)
+      robot = MartianRobot.new([2,2], "N", mars)
+      robot.report_final_position('FFF')
+      new_robot = MartianRobot.new([2,3], "N", mars)
+      position = new_robot.report_final_position('FRFLFFF')
+      expect(position).to eq(:lost)
     end
   end
 

--- a/spec/martian_robot_spec.rb
+++ b/spec/martian_robot_spec.rb
@@ -85,7 +85,7 @@ RSpec.describe MartianRobot do
 
   describe "Robot gets lost" do
     it "returns :lost if robot final position is outside the limits" do
-      mars = Mars.new(2)
+      mars = Mars.new(1)
       robot = MartianRobot.new([1,1], "E", mars)
       final_position = robot.report_final_position('F')
       expect(final_position).to eq(:lost)
@@ -109,10 +109,10 @@ RSpec.describe MartianRobot do
       expect(robot.report_final_position('FFFF')).to eq(:lost)
     end
 
-    it "returns :lost if robot gets back once it's lost" do
+    it "returns :lost if robot gets back inside the grid once it got out" do
       mars = Mars.new(3)
       robot = MartianRobot.new([1,1], "N", mars)
-      expect(robot.report_final_position('FFFFRRFFFF')).to eq(:lost)
+      expect(robot.report_final_position('FFFRRFFF')).to eq(:lost)
     end
   end
 

--- a/spec/martian_robot_spec.rb
+++ b/spec/martian_robot_spec.rb
@@ -52,9 +52,9 @@ RSpec.describe MartianRobot do
     expect(robot.report_final_position("FRF")).to eq([2,2])
   end
 
-  it "returns [2,0] if robot starts from [2,2] 'S' and receives 'FFFRRF'" do
+  it "returns [2,1] if robot starts from [2,2] 'S' and receives 'FFRRF'" do
     robot = MartianRobot.new([2,2], "S", mars)
-    expect(robot.report_final_position("FFFRRF")).to eq([2,0])
+    expect(robot.report_final_position("FFRRF")).to eq([2,1])
   end
 
   it "returns [2,2] if robot starts from [1,1] 'E' and receives 'FLF'" do
@@ -77,10 +77,10 @@ RSpec.describe MartianRobot do
     expect(robot.report_final_position("FRLF")).to eq([1,3])
   end
 
-  it "returns [1,0] if robot starts from [1,1] 'W' and receives 'FFRLFLLFFFRRRLLF'" do
-    robot = MartianRobot.new([1,1], "W", mars)
-    final_position = robot.report_final_position("FFRLFLLFFFRRRLLF")
-    expect(final_position).to eq([1,0])
+  it "returns [0,3] if robot starts from [2,2] 'W' and receives 'FRFLFRRL'" do
+    robot = MartianRobot.new([2,2], "W", mars)
+    final_position = robot.report_final_position("FRFLFRRL")
+    expect(final_position).to eq([0,3])
   end
 
   describe "Robot gets lost" do
@@ -107,6 +107,12 @@ RSpec.describe MartianRobot do
       mars = Mars.new(3)
       robot = MartianRobot.new([1,1], "S", mars)
       expect(robot.report_final_position('FFFF')).to eq(:lost)
+    end
+
+    it "returns :lost if robot gets back once it's lost" do
+      mars = Mars.new(3)
+      robot = MartianRobot.new([1,1], "N", mars)
+      expect(robot.report_final_position('FFFFRRFFFF')).to eq(:lost)
     end
   end
 

--- a/spec/martian_robot_spec.rb
+++ b/spec/martian_robot_spec.rb
@@ -1,5 +1,3 @@
-#$LOAD_PATH << File.expand_path('../lib', __FILE__)
-
 require_relative '../lib/martian_robot'
 require_relative '../lib/mars'
 
@@ -83,66 +81,66 @@ RSpec.describe MartianRobot do
     expect(final_position).to eq([0,3])
   end
 
-  # describe "Robot gets lost" do
-  #   it "returns :lost if robot final position is outside the limits" do
-  #     mars = Mars.new(1)
-  #     robot = MartianRobot.new([1,1], "E", mars)
-  #     final_position = robot.report_final_position('F')
-  #     expect(final_position).to eq(:lost)
-  #   end
-  #
-  #   it "returns :lost if robot final position is outside the limits" do
-  #     mars = Mars.new(3)
-  #     robot = MartianRobot.new([1,1], "W", mars)
-  #     expect(robot.report_final_position('FFFF')).to eq(:lost)
-  #   end
-  #
-  #   it "returns :lost if robot final position is outside the limits" do
-  #     mars = Mars.new(3)
-  #     robot = MartianRobot.new([1,1], "N", mars)
-  #     expect(robot.report_final_position('FFFF')).to eq(:lost)
-  #   end
-  #
-  #   it "returns :lost if robot final position is outside the limits" do
-  #     mars = Mars.new(3)
-  #     robot = MartianRobot.new([1,1], "S", mars)
-  #     expect(robot.report_final_position('FFFF')).to eq(:lost)
-  #   end
-  #
-  #   it "returns :lost if robot gets back inside the grid once it got out" do
-  #     mars = Mars.new(3)
-  #     robot = MartianRobot.new([1,1], "N", mars)
-  #     expect(robot.report_final_position('FFFRRFFF')).to eq(:lost)
-  #   end
-  # end
+  describe "Robot gets lost" do
+    it "returns :lost if robot final position is outside the limits" do
+      mars = Mars.new(1)
+      robot = MartianRobot.new([1,1], "E", mars)
+      final_position = robot.report_final_position('F')
+      expect(final_position).to eq(:lost)
+    end
+
+    it "returns :lost if robot final position is outside the limits" do
+      mars = Mars.new(3)
+      robot = MartianRobot.new([1,1], "W", mars)
+      expect(robot.report_final_position('FFFF')).to eq(:lost)
+    end
+
+    it "returns :lost if robot final position is outside the limits" do
+      mars = Mars.new(3)
+      robot = MartianRobot.new([1,1], "N", mars)
+      expect(robot.report_final_position('FFFF')).to eq(:lost)
+    end
+
+    it "returns :lost if robot final position is outside the limits" do
+      mars = Mars.new(3)
+      robot = MartianRobot.new([1,1], "S", mars)
+      expect(robot.report_final_position('FFFF')).to eq(:lost)
+    end
+
+    it "returns :lost if robot gets back inside the grid once it got out" do
+      mars = Mars.new(3)
+      robot = MartianRobot.new([1,1], "N", mars)
+      expect(robot.report_final_position('FFFRRFFF')).to eq(:lost)
+    end
+  end
 
   describe "Robot leaves scent" do
     it "leaves its scent on the spot in planet before getting off the confines and returns coordinates of that spot" do
       mars = Mars.new(4)
       lost_robot = MartianRobot.new([1,1], "N", mars)
-      last_position = lost_robot.report_final_position('FRFLFRFFFF')
-      expect(last_position).to eq([[4,3],'E'])
+      lost_robot.report_final_position('FRFLFRFFFF')
+      expect(lost_robot.last_position_before_lost).to eq([4,3])
     end
 
     it "leaves its scent on the spot in planet before getting off the confines and returns coordinates of that spot" do
       mars = Mars.new(4)
       lost_robot = MartianRobot.new([2,2], "E", mars)
-      last_position = lost_robot.report_final_position('FRFFFF')
-      expect(last_position).to eq([[3,0],'S'])
+      lost_robot.report_final_position('FRFFFF')
+      expect(lost_robot.last_position_before_lost).to eq([3,0])
     end
 
     it "leaves its scent on the spot in planet before getting off the confines and returns coordinates of that spot" do
       mars = Mars.new(4)
       lost_robot = MartianRobot.new([2,2], "W", mars)
-      last_position = lost_robot.report_final_position('FLFRFFF')
-      expect(last_position).to eq([[0,1],'W'])
+      lost_robot.report_final_position('FLFRFFF')
+      expect(lost_robot.last_position_before_lost).to eq([0,1])
     end
 
     it "leaves its scent on the spot in planet before getting off the confines and returns coordinates of that spot" do
       mars = Mars.new(4)
       lost_robot = MartianRobot.new([2,2], "N", mars)
-      last_position = lost_robot.report_final_position('FRFLFFFF')
-      expect(last_position).to eq([[3,4],'N'])
+      lost_robot.report_final_position('FRFLFFFF')
+      expect(lost_robot.last_position_before_lost).to eq([3,4])
     end
   end
 

--- a/spec/martian_robot_spec.rb
+++ b/spec/martian_robot_spec.rb
@@ -83,66 +83,66 @@ RSpec.describe MartianRobot do
     expect(final_position).to eq([0,3])
   end
 
-  describe "Robot gets lost" do
-    it "returns :lost if robot final position is outside the limits" do
-      mars = Mars.new(1)
-      robot = MartianRobot.new([1,1], "E", mars)
-      final_position = robot.report_final_position('F')
-      expect(final_position).to eq(:lost)
-    end
-
-    it "returns :lost if robot final position is outside the limits" do
-      mars = Mars.new(3)
-      robot = MartianRobot.new([1,1], "W", mars)
-      expect(robot.report_final_position('FFFF')).to eq(:lost)
-    end
-
-    it "returns :lost if robot final position is outside the limits" do
-      mars = Mars.new(3)
-      robot = MartianRobot.new([1,1], "N", mars)
-      expect(robot.report_final_position('FFFF')).to eq(:lost)
-    end
-
-    it "returns :lost if robot final position is outside the limits" do
-      mars = Mars.new(3)
-      robot = MartianRobot.new([1,1], "S", mars)
-      expect(robot.report_final_position('FFFF')).to eq(:lost)
-    end
-
-    it "returns :lost if robot gets back inside the grid once it got out" do
-      mars = Mars.new(3)
-      robot = MartianRobot.new([1,1], "N", mars)
-      expect(robot.report_final_position('FFFRRFFF')).to eq(:lost)
-    end
-  end
+  # describe "Robot gets lost" do
+  #   it "returns :lost if robot final position is outside the limits" do
+  #     mars = Mars.new(1)
+  #     robot = MartianRobot.new([1,1], "E", mars)
+  #     final_position = robot.report_final_position('F')
+  #     expect(final_position).to eq(:lost)
+  #   end
+  #
+  #   it "returns :lost if robot final position is outside the limits" do
+  #     mars = Mars.new(3)
+  #     robot = MartianRobot.new([1,1], "W", mars)
+  #     expect(robot.report_final_position('FFFF')).to eq(:lost)
+  #   end
+  #
+  #   it "returns :lost if robot final position is outside the limits" do
+  #     mars = Mars.new(3)
+  #     robot = MartianRobot.new([1,1], "N", mars)
+  #     expect(robot.report_final_position('FFFF')).to eq(:lost)
+  #   end
+  #
+  #   it "returns :lost if robot final position is outside the limits" do
+  #     mars = Mars.new(3)
+  #     robot = MartianRobot.new([1,1], "S", mars)
+  #     expect(robot.report_final_position('FFFF')).to eq(:lost)
+  #   end
+  #
+  #   it "returns :lost if robot gets back inside the grid once it got out" do
+  #     mars = Mars.new(3)
+  #     robot = MartianRobot.new([1,1], "N", mars)
+  #     expect(robot.report_final_position('FFFRRFFF')).to eq(:lost)
+  #   end
+  # end
 
   describe "Robot leaves scent" do
     it "leaves its scent on the spot in planet before getting off the confines and returns coordinates of that spot" do
       mars = Mars.new(4)
       lost_robot = MartianRobot.new([1,1], "N", mars)
-      # final_position = new_robot.report_final_position('FRFLFRFFFF')
-      expect(lost_robot.leave_scent_before_getting_lost([6,3])).to eq([4,3])
+      last_position = lost_robot.report_final_position('FRFLFRFFFF')
+      expect(last_position).to eq([[4,3],'E'])
     end
 
     it "leaves its scent on the spot in planet before getting off the confines and returns coordinates of that spot" do
       mars = Mars.new(4)
       lost_robot = MartianRobot.new([2,2], "E", mars)
-      # final_position = new_robot.report_final_position('FRFFFF')
-      expect(lost_robot.leave_scent_before_getting_lost([3,-2])).to eq([3,0])
+      last_position = lost_robot.report_final_position('FRFFFF')
+      expect(last_position).to eq([[3,0],'S'])
     end
 
     it "leaves its scent on the spot in planet before getting off the confines and returns coordinates of that spot" do
       mars = Mars.new(4)
       lost_robot = MartianRobot.new([2,2], "W", mars)
-      # final_position = new_robot.report_final_position('FLFRFFF')
-      expect(lost_robot.leave_scent_before_getting_lost([-2,1])).to eq([0,1])
+      last_position = lost_robot.report_final_position('FLFRFFF')
+      expect(last_position).to eq([[0,1],'W'])
     end
 
     it "leaves its scent on the spot in planet before getting off the confines and returns coordinates of that spot" do
       mars = Mars.new(4)
       lost_robot = MartianRobot.new([2,2], "N", mars)
-      # final_position = new_robot.report_final_position('FRFLFFFF')
-      expect(lost_robot.leave_scent_before_getting_lost([3,7])).to eq([3,4])
+      last_position = lost_robot.report_final_position('FRFLFFFF')
+      expect(last_position).to eq([[3,4],'N'])
     end
   end
 

--- a/spec/martian_robot_spec.rb
+++ b/spec/martian_robot_spec.rb
@@ -107,7 +107,7 @@ RSpec.describe MartianRobot do
       expect(robot.report_final_position('FFFF')).to eq(:lost)
     end
 
-    xit "returns :lost if robot gets back inside the grid once it got out" do
+    it "returns :lost if robot gets back inside the confines once it got out" do
       mars = Mars.new(3)
       robot = MartianRobot.new([1,1], "N", mars)
       expect(robot.report_final_position('FFFRRFFF')).to eq(:lost)
@@ -173,7 +173,7 @@ RSpec.describe MartianRobot do
       expect(position).to eq([2,4])
     end
 
-    it "retuns :lost if it gets off the confines and no other robot left its scent on the same position before" do
+    it "returns :lost if it gets off the confines and no other robot left its scent on the same position before" do
       mars = Mars.new(4)
       robot = MartianRobot.new([2,2], "N", mars)
       robot.report_final_position('FFF')

--- a/spec/movements_spec.rb
+++ b/spec/movements_spec.rb
@@ -6,44 +6,50 @@ RSpec.describe Movements do
 
   let (:movements) {Movements.new}
 
-  it "returns E if robot's initial orientation is N" do
-    expect(movements.change_orientation_clockwise("N")).to eq("E")
+  describe "Robot turns clockwise" do
+    it "returns E if robot's initial orientation is N" do
+      expect(movements.change_orientation_clockwise("N")).to eq("E")
+    end
+
+    it "returns W if robot's initial orientation is S" do
+      expect(movements.change_orientation_clockwise("S")).to eq("W")
+    end
   end
 
-  it "returns W if robot's initial orientation is S" do
-    expect(movements.change_orientation_clockwise("S")).to eq("W")
+  describe "Robot turns anticlockwise" do
+    it "returns S if robot's initial orientation is W" do
+      expect(movements.change_orientation_anticlockwise("W")).to eq("S")
+    end
+
+    it "returns N if robot's initial orientation is E" do
+      expect(movements.change_orientation_anticlockwise("E")).to eq("N")
+    end
   end
 
-  it "returns S if robot's initial orientation is W" do
-    expect(movements.change_orientation_anticlockwise("W")).to eq("S")
-  end
+  describe "Robot moves forward" do
+    it "returns 2 as value for coordinate x if robot starts from [1,1] and moves East" do
+      coordinates = [1,1]
+      movements.move_forward('E',coordinates)
+      expect(coordinates[0]).to eq(2)
+    end
 
-  it "returns N if robot's initial orientation is E" do
-    expect(movements.change_orientation_anticlockwise("E")).to eq("N")
-  end
+    it "returns 2 as value for coordinate y if robot starts from [1,1] and moves North" do
+      coordinates = [1,1]
+      movements.move_forward('N',coordinates)
+      expect(coordinates[1]).to eq(2)
+    end
 
-  it "returns 2 as value for coordinate x if robot starts from [1,1] and moves East" do
-    coordinates = [1,1]
-    movements.move_forward('E',coordinates)
-    expect(coordinates[0]).to eq(2)
-  end
+    it "returns 4 as value for coordinate x if robot starts from [5,3] and moves West" do
+      coordinates = [5,3]
+      movements.move_forward('W',coordinates)
+      expect(coordinates[0]).to eq(4)
+    end
 
-  it "returns 2 as value for coordinate y if robot starts from [1,1] and moves North" do
-    coordinates = [1,1]
-    movements.move_forward('N',coordinates)
-    expect(coordinates[1]).to eq(2)
+    it "returns 8 as value for coordinate y if robot starts from [7,9] and moves South" do
+      coordinates = [7,9]
+      movements.move_forward('S',coordinates)
+      expect(coordinates[1]).to eq(8)
+    end
   end
-
-  it "returns 4 as value for coordinate x if robot starts from [5,3] and moves West" do
-    coordinates = [5,3]
-    movements.move_forward('W',coordinates)
-    expect(coordinates[0]).to eq(4)
-  end
-
-  it "returns 8 as value for coordinate y if robot starts from [7,9] and moves South" do
-    coordinates = [7,9]
-    movements.move_forward('S',coordinates)
-    expect(coordinates[1]).to eq(8)
-  end
-
+  
 end

--- a/spec/movements_spec.rb
+++ b/spec/movements_spec.rb
@@ -1,6 +1,4 @@
-$LOAD_PATH << File.expand_path('. ./lib', __FILE__)
-
-require 'movements'
+require_relative '../lib/movements'
 
 RSpec.describe Movements do
 
@@ -51,5 +49,5 @@ RSpec.describe Movements do
       expect(coordinates[1]).to eq(8)
     end
   end
-  
+
 end


### PR DESCRIPTION
Implemented new feature that makes robots stop if a previous robot got lost from the same point before.
Lost robots leave a robot “scent” that prohibits future robots from dropping off the world at the same grid point. The scent is left at the last grid position the robot occupied before disappearing over the edge. An instruction to move “off” the world from a grid point from which a robot has been previously lost is simply ignored by the current robot. A robot will stop at the point where a previous robot that had disappeared has left its scent regardless of its current orientation (that means of its direction.)